### PR TITLE
Add development env automation and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,46 @@ Pseudo Algorithm at a high level after reading the `SIPCluster` CR:
 
 SIPCluster CR will exists within the Control phase for a Tenant cluster.
 
+## Development environment
+
+### Kind kubernetes cluster
+Fastest way to set up a k8s cluster for development env is to use kind to set it up
+
+#### Install kind on linux (amd64 arch)
+
+```
+# curl -Lo kind https://kind.sigs.k8s.io/dl/v0.9.0/kind-linux-amd64
+# sudo install  -m 755 --owner=root --group=root kind /usr/local/bin
+# rm kind
+```
+
+More information on how to install kind binary can be found be found [here](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+
+#### Create k8s cluster with kind
+
+```
+# make kind-create
+# kubectl get nodes
+```
+
+### Deploy sip operator on top of kind cluster
+kind-load-image target will build docker image from the current state of your local
+git repository and upload it to kind cluster to be available for kubelet.
+
+```
+# make kind-load-image
+# make deploy
+```
+
+Now you have a working k8s cluster with sip installed on it with your changes to SIP operator
+
+### Deliver sip CRs to kubernetes
+
+Use kubectl apply to deliver SIP CRs and BaremetalHost CRDs to kubernetes cluster
+
+```
+# kubectl apply -f config/samples/airship_v1beta1_sipcluster.yaml
+# kubectl apply -f config/samples/bmh/baremetalhosts.metal3.io.yaml
+```
+Now you are ready to craft and add BaremetalHost CRs into cluster, check samples directory
+to find BaremetalHost examples there.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -28,7 +28,7 @@ spec:
         args:
         - --enable-leader-election
         image: quay.io/jezogwza/airship:sip.v1
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: manager
         resources:
           limits:

--- a/config/samples/airship_v1beta1_sipcluster.yaml
+++ b/config/samples/airship_v1beta1_sipcluster.yaml
@@ -2,7 +2,7 @@ apiVersion: airship.airshipit.org/v1
 kind: SIPCluster
 metadata:
   name: sipcluster-test1
-  namespace: sip-cluster-system
+  namespace: sipcluster-system
 spec:
     config:
         cluster-name: cname


### PR DESCRIPTION
Small automation that will allow to build kind cluster using `make`, and upload locally built image to the running kind cluster to avoid having to push image to remote/local registries