### PR TITLE
Fix showLabels script to filter on bmh flavor

### DIFF
--- a/config/samples/bmh/showLabels
+++ b/config/samples/bmh/showLabels
@@ -1,2 +1,3 @@
 SCHEDULED=$1
-kubectl get baremetalhosts --all-namespaces -l sip.airshipit.org/sip-scheduled=$SCHEDULED --show-labels|grep -v NAME|awk '{print "____________\n",$2,"\n\t",$5,$6}'|sed -e's/,/\n\t/g'
+FLAVOR=$2
+kubectl get baremetalhosts --all-namespaces -l sip.airshipit.org/sip-scheduled=$SCHEDULED,airshipit.org/vino-flavor=$FLAVOR --show-labels|grep -v NAME|awk '{print "____________\n",$2,"\n\t",$5,$6}'|sed -e's/,/\n\t/g'


### PR DESCRIPTION
The showLabels script only checks if a bmh is scheduled or not based
on the passed argument (true or false), but does not correctly filter
the type of bmh flavor (master or worker).