### PR TITLE
Fix node-type label

### DIFF
--- a/config/samples/bmh/cleanLabels
+++ b/config/samples/bmh/cleanLabels
@@ -1,6 +1,6 @@
-kubectl label baremetalhosts -n metal3 --overwrite rdm9r006o001 sip.airshipit.org/sip-scheduled=false sip.airshipit.org/note-type- sip.airshipit.org/workload-cluster- sip-scheduled-
-kubectl label baremetalhosts -n metal3 --overwrite rdm9r006o002 sip.airshipit.org/sip-scheduled=false sip.airshipit.org/note-type- sip.airshipit.org/workload-cluster- sip-scheduled-
-kubectl label baremetalhosts -n metal3 --overwrite rdm9r007o001 sip.airshipit.org/sip-scheduled=false sip.airshipit.org/note-type- sip.airshipit.org/workload-cluster- sip-scheduled-
-kubectl label baremetalhosts -n metal3 --overwrite rdm9r007o002 sip.airshipit.org/sip-scheduled=false sip.airshipit.org/note-type- sip.airshipit.org/workload-cluster- sip-scheduled-
-kubectl label baremetalhosts -n metal3 --overwrite rdm9r008c002 sip.airshipit.org/sip-scheduled=false sip.airshipit.org/note-type- sip.airshipit.org/workload-cluster- sip-scheduled-
-kubectl label baremetalhosts -n metal3 --overwrite rdm9r009c002 sip.airshipit.org/sip-scheduled=false sip.airshipit.org/note-type- sip.airshipit.org/workload-cluster- sip-scheduled-
+kubectl label baremetalhosts -n metal3 --overwrite rdm9r006o001 sip.airshipit.org/sip-scheduled=false sip.airshipit.org/node-type- sip.airshipit.org/workload-cluster- sip-scheduled-
+kubectl label baremetalhosts -n metal3 --overwrite rdm9r006o002 sip.airshipit.org/sip-scheduled=false sip.airshipit.org/node-type- sip.airshipit.org/workload-cluster- sip-scheduled-
+kubectl label baremetalhosts -n metal3 --overwrite rdm9r007o001 sip.airshipit.org/sip-scheduled=false sip.airshipit.org/node-type- sip.airshipit.org/workload-cluster- sip-scheduled-
+kubectl label baremetalhosts -n metal3 --overwrite rdm9r007o002 sip.airshipit.org/sip-scheduled=false sip.airshipit.org/node-type- sip.airshipit.org/workload-cluster- sip-scheduled-
+kubectl label baremetalhosts -n metal3 --overwrite rdm9r008c002 sip.airshipit.org/sip-scheduled=false sip.airshipit.org/node-type- sip.airshipit.org/workload-cluster- sip-scheduled-
+kubectl label baremetalhosts -n metal3 --overwrite rdm9r009c002 sip.airshipit.org/sip-scheduled=false sip.airshipit.org/node-type- sip.airshipit.org/workload-cluster- sip-scheduled-

--- a/pkg/vbmh/machines.go
+++ b/pkg/vbmh/machines.go
@@ -74,7 +74,7 @@ const (
 	SipClusterLabelName = "workload-cluster"
 	SipClusterLabel     = BaseAirshipSelector + "/" + SipClusterLabelName
 
-	SipNodeTypeLabelName = "note-type"
+	SipNodeTypeLabelName = "node-type"
 	SipNodeTypeLabel     = BaseAirshipSelector + "/" + SipNodeTypeLabelName
 )
 


### PR DESCRIPTION
The node-type label applied by SIP is spelled incorrectly as
"note-type". This change fixes it.

Fixes #19