### PR TITLE
Add NetworkData validation to BMH

### DIFF
--- a/config/crd/bases/airship.airshipit.org_sipclusters.yaml
+++ b/config/crd/bases/airship.airshipit.org_sipclusters.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   name: sipclusters.airship.airshipit.org
 spec:
@@ -115,5 +115,5 @@ status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: null
-  storedVersions: null
+  conditions: []
+  storedVersions: []

--- a/pkg/vbmh/errors.go
+++ b/pkg/vbmh/errors.go
@@ -2,6 +2,9 @@ package vbmh
 
 import (
 	"fmt"
+
+	metal3 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+
 	airshipv1 "sipcluster/pkg/api/v1"
 )
 
@@ -42,4 +45,13 @@ type ErrorUknownSpreadTopology struct {
 
 func (e ErrorUknownSpreadTopology) Error() string {
 	return fmt.Sprintf("Uknown spread topology '%s'", e.Topology)
+}
+
+// ErrorNetworkDataNotFound is returned when NetworkData metadata is missing from BMH
+type ErrorNetworkDataNotFound struct {
+	BMH metal3.BareMetalHost
+}
+
+func (e ErrorNetworkDataNotFound) Error() string {
+	return fmt.Sprintf("vBMH Host %v does not define NetworkData, but is required for scheduling.", e.BMH)
 }


### PR DESCRIPTION
This change introduces validation to ensure that NetworkData is present
when creating a machine. If not, the machine is skipped and placed in
NotScheduled state.

This change also includes a test case to validate this behavior occurs.

Signed-off-by: Alexander Hughes <Alexander.Hughes@pm.me>