### PR TITLE
Add scheduling constraint integration tests

### DIFF
--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -16,6 +16,8 @@ const (
 	sipScheduleLabel = "sip.airshipit.org/sip-scheduled"
 	sipServerLabel   = "sip.airshipit.org/server"
 
+	VinoFlavorLabel = "airshipit.org/vino-flavor"
+
 	networkDataContent = `
 {
     "links": [


### PR DESCRIPTION
This change adds integration tests to validate that SIP honors per-node
and per-rack scheduling constraints.